### PR TITLE
Start converting Koala into a subclass of Koa

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,63 +16,61 @@ const req = require('./request');
 const res = require('./response');
 const App = require('./app');
 
-module.exports = function koala(options) {
-  options = options || {};
+module.exports = class Koala extends Koa {
+  constructor(options = {}) {
+    super();
 
-  const app = new Koa();
+    middleware(this, options);
+    merge(this.context, ctx);
+    merge(this.request, req);
+    merge(this.response, res);
+    App(this);
 
-  middleware(app, options);
-  merge(app.context, ctx);
-  merge(app.request, req);
-  merge(app.response, res);
-  App(app);
+    // handlers
+    this.pageNotFoundHandler = pageNotFoundHandler;
 
-  // handlers
-  app.pageNotFoundHandler = pageNotFoundHandler;
+    // properties
+    this.jsonStrict = options.jsonStrict !== false;
 
-  // properties
-  app.jsonStrict = options.jsonStrict !== false;
+    // proto stuff
+    this.use(conditional());
+    this.use(new CSRF({
+      invalidSessionSecretMessage: 'Invalid session secret',
+      invalidSessionSecretStatusCode: 403,
+      invalidTokenMessage: 'Invalid CSRF token',
+      invalidTokenStatusCode: 403,
+      excludedMethods: [ 'GET', 'HEAD', 'OPTIONS' ],
+      disableQuery: false
+    }));
+    this.use(etag());
+    this.use(bodyParser());
+    // this.use(convert(trace));
+    const pug = new Pug({
+      debug: false,
+      pretty: false,
+      compileDebug: false,
+      locals: {},
+      basedir: `${__dirname}/templates`,
+      helperPath: [],
+      app: this // equals to pug.use(this) and this.use(pug.middleware)
+    });
+    this.use(error({
+      engine: 'pug',
+      template: `${__dirname}/templates/error.pug`
+    }));
+    // nested query string support
+    if (options.qs) {
+      this.use(new Qs());
+      this.querystring = require('qs');
+    }
 
-  // proto stuff
-  app.use(conditional());
-  app.use(new CSRF({
-    invalidSessionSecretMessage: 'Invalid session secret',
-    invalidSessionSecretStatusCode: 403,
-    invalidTokenMessage: 'Invalid CSRF token',
-    invalidTokenStatusCode: 403,
-    excludedMethods: [ 'GET', 'HEAD', 'OPTIONS' ],
-    disableQuery: false
-  }));
-  app.use(etag());
-  app.use(bodyParser());
-  // app.use(convert(trace));
-  const pug = new Pug({
-    debug: false,
-    pretty: false,
-    compileDebug: false,
-    locals: {},
-    basedir: `${__dirname}/templates`,
-    helperPath: [],
-    app: app // equals to pug.use(app) and app.use(pug.middleware)
-  });
-  app.use(error({
-    engine: 'pug',
-    template: `${__dirname}/templates/error.pug`
-  }));
-  // nested query string support
-  if (options.qs) {
-    app.use(new Qs());
-    app.querystring = require('qs');
+    // jsonp support
+    if (options.jsonp) {
+      this.use(new SafeJsonP({jsonp: options.jsonp}));
+    }
+
+    if (process.env.NODE_ENV !== 'production' && this.debug) this.debug();
   }
-
-  // jsonp support
-  if (options.jsonp) {
-    app.use(new SafeJsonP({jsonp: options.jsonp}));
-  }
-
-  if (process.env.NODE_ENV !== 'production' && app.debug) app.debug();
-
-  return app;
 }
 
 async function pageNotFoundHandler(next) {

--- a/test/app/basic-auth.js
+++ b/test/app/basic-auth.js
@@ -1,18 +1,18 @@
 
 describe('Basic Auth', function () {
   it('should return the value', function (done) {
-    var app = koala()
+    var app = new Koala()
     app.use(async (next) => {
       this.body = this.request.basicAuth
     })
 
     request(app.listen())
-    .get('/')
-    .auth('username', 'password')
-    .expect(200)
-    .expect({
-      name: 'username',
-      pass: 'password',
-    }, done)
+       .get('/')
+       .auth('username', 'password')
+       .expect(200)
+       .expect({
+         name: 'username',
+         pass: 'password',
+       }, done)
   })
 })

--- a/test/app/body-parsing.js
+++ b/test/app/body-parsing.js
@@ -2,7 +2,7 @@
 describe('Body Parsing', function () {
   describe('.request.json()', function () {
     it('should parse a json body', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* () {
         this.body = yield* this.request.json()
       })
@@ -17,7 +17,7 @@ describe('Body Parsing', function () {
     })
 
     it('should throw on non-objects in strict mode', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* () {
         this.body = yield* this.request.json()
       })
@@ -29,7 +29,7 @@ describe('Body Parsing', function () {
     })
 
     it('should not throw on non-objects in non-strict mode', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.jsonStrict = false
       app.use(function* () {
         this.body = yield* this.request.json()
@@ -45,7 +45,7 @@ describe('Body Parsing', function () {
 
   describe('.request.urlencoded()', function () {
     it('should parse a urlencoded body', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* () {
         this.body = yield* this.request.urlencoded()
       })
@@ -58,7 +58,7 @@ describe('Body Parsing', function () {
     })
 
     it('should not support nested query strings by default', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* () {
         this.body = yield* this.request.urlencoded()
       })
@@ -75,7 +75,7 @@ describe('Body Parsing', function () {
     })
 
     it('should support nested query strings with options.qs=true', function (done) {
-      var app = koala({
+      var app = new Koala({
         qs: true
       })
       app.use(function* () {
@@ -100,7 +100,7 @@ describe('Body Parsing', function () {
 
   describe('.request.text()', function () {
     it('should get the raw text body', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* () {
         this.body = yield* this.request.text()
         assert.equal('string', typeof this.body)
@@ -113,7 +113,7 @@ describe('Body Parsing', function () {
     })
 
     it('should throw if the body is too large', function (done) {
-      var app = koala();
+      var app = new Koala();
       app.use(function* () {
         yield* this.request.text('1kb')
         this.body = 204
@@ -127,7 +127,7 @@ describe('Body Parsing', function () {
 
   describe('.request.buffer()', function () {
     it('should get the raw buffer body', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* () {
         this.body = yield* this.request.buffer()
         assert(Buffer.isBuffer(this.body))
@@ -140,7 +140,7 @@ describe('Body Parsing', function () {
     })
 
     it('should throw if the body is too large', function (done) {
-      var app = koala();
+      var app = new Koala();
       app.use(function* () {
         yield* this.request.buffer('1kb')
         this.body = 204
@@ -158,7 +158,7 @@ describe('Body Parsing', function () {
 
   describe('Expect: 100-continue', function () {
     it('should send 100-continue', function (done) {
-      var app = koala();
+      var app = new Koala();
       app.use(function* () {
         this.body = yield* this.request.json()
       })

--- a/test/app/cache-control.js
+++ b/test/app/cache-control.js
@@ -2,7 +2,7 @@
 describe('Cache-Control', function () {
   describe('should be available as', function () {
     it('this.cc()', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.cc(1000)
         this.status = 204
@@ -12,7 +12,7 @@ describe('Cache-Control', function () {
     })
 
     it('this.cacheControl()', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.cacheControl(1000)
         this.status = 204
@@ -22,7 +22,7 @@ describe('Cache-Control', function () {
     })
 
     it('this.response.cc()', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cc(1000)
         this.status = 204
@@ -32,7 +32,7 @@ describe('Cache-Control', function () {
     })
 
     it('this.cacheControl()', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cacheControl(1000)
         this.status = 204
@@ -44,7 +44,7 @@ describe('Cache-Control', function () {
 
   describe('when the value is a number', function () {
     it('should set "public, max-age="', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cacheControl(1000000)
         this.status = 204
@@ -56,7 +56,7 @@ describe('Cache-Control', function () {
 
   describe('when the value is a time string', function () {
     it('should set "public, max-age="', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cacheControl('1 hour')
         this.status = 204
@@ -68,7 +68,7 @@ describe('Cache-Control', function () {
 
   describe('when the value is "false"', function () {
     it('should set "private, no-cache"', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cacheControl(false)
         this.status = 204
@@ -80,7 +80,7 @@ describe('Cache-Control', function () {
 
   describe('when the value is a string', function () {
     it('should juset set it', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cacheControl('lol')
         this.status = 204
@@ -92,7 +92,7 @@ describe('Cache-Control', function () {
 
   describe('when the value is anything else', function () {
     it('should throw', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.cacheControl(true)
         this.status = 204

--- a/test/app/conditional-get.js
+++ b/test/app/conditional-get.js
@@ -3,7 +3,7 @@ describe('Conditional-Get', function () {
   describe('when a body is set', function () {
     var etag
 
-    var app = koala()
+    var app = new Koala()
     app.use(function* (next) {
       this.body = 'hello'
     })

--- a/test/app/headers.js
+++ b/test/app/headers.js
@@ -2,7 +2,7 @@
 describe('Set headers', function () {
   describe('X-Response-Time', function() {
     it('should get X-Response-Time correctly by default', function(done) {
-      var app = koala()
+      var app = new Koala()
 
       request(app.listen())
       .get('/')
@@ -11,7 +11,7 @@ describe('Set headers', function () {
       .end(done)
     })
     it('should not get X-Response-Time by options.responseTime = false', function(done) {
-      var app = koala({
+      var app = new Koala({
         responseTime: false
       })
 
@@ -27,7 +27,7 @@ describe('Set headers', function () {
 
   describe('X-Frame-Options', function() {
     it('should get X-Frame-Options DENY by default', function(done) {
-      var app = koala()
+      var app = new Koala()
 
       request(app.listen())
       .get('/')
@@ -36,7 +36,7 @@ describe('Set headers', function () {
       .end(done)
     })
     it('should not get X-Frame-Options by xframe = false', function(done) {
-      var app = koala({
+      var app = new Koala({
         security: {
           xframe: false
         }
@@ -51,7 +51,7 @@ describe('Set headers', function () {
       })
     })
     it('should get X-Frame-Options DENY by xframe = true', function(done) {
-      var app = koala({
+      var app = new Koala({
         security: {
           xframe: true
         }
@@ -64,7 +64,7 @@ describe('Set headers', function () {
       .end(done)
     })
     it('should get X-Frame-Options SAMEORIGIN by xframe = same', function(done) {
-      var app = koala({
+      var app = new Koala({
         security: {
           xframe: 'same'
         }

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -3,7 +3,7 @@ http = require('http')
 assert = require('assert')
 request = require('supertest')
 
-koala = require('../..')
+Koala = require('../..')
 
 require('fs').readdirSync(__dirname).forEach(function (name) {
   if (name[0] === '.') return

--- a/test/app/jsonp.js
+++ b/test/app/jsonp.js
@@ -1,7 +1,7 @@
 
 describe('jsonp', function () {
   it('should return jsonp response', function (done) {
-    var app = koala({
+    var app = new Koala({
       jsonp: {
         callback: '_callback'
       }
@@ -17,7 +17,7 @@ describe('jsonp', function () {
   })
 
   it('should return json response', function (done) {
-    var app = koala({
+    var app = new Koala({
       jsonp: {
         callback: '_callback'
       }

--- a/test/app/middleware.js
+++ b/test/app/middleware.js
@@ -2,7 +2,7 @@
 describe('Middlewares', function () {
   describe('Session', function() {
     it('should has this.session by default', function(done) {
-      var app = koala()
+      var app = new Koala()
 
       app.use(function *() {
         this.body = this.session;
@@ -14,7 +14,7 @@ describe('Middlewares', function () {
       .end(done)
     })
     it('should has no this.session by options.session = false', function(done) {
-      var app = koala({
+      var app = new Koala({
         session: false
       })
 

--- a/test/app/object-streams.js
+++ b/test/app/object-streams.js
@@ -3,7 +3,7 @@ var PassThrough = require('stream').PassThrough
 
 describe('Object Streams', function () {
   it('should be supported', function (done) {
-    var app = koala()
+    var app = new Koala()
     app.use(function* (next) {
       var body = this.body = new PassThrough({
         objectMode: true

--- a/test/app/polyfill.js
+++ b/test/app/polyfill.js
@@ -2,7 +2,7 @@
 describe.skip('Polyfills', function () {
   describe('GET /polyfill.js', function () {
     it('should return the polyfill', function (done) {
-      var app = koala()
+      var app = new Koala()
       request(app.listen())
       .get('/polyfill.js')
       .expect(200)

--- a/test/app/query-string.js
+++ b/test/app/query-string.js
@@ -2,7 +2,7 @@
 describe('Nested Query Strings', function () {
   describe('when options.qs = false', function () {
     it('should not support nested query strings', function (done) {
-      var app = koala()
+      var app = new Koala()
       app.use(function* (next) {
         this.response.body = this.request.query
       })
@@ -23,7 +23,7 @@ describe('Nested Query Strings', function () {
 
   describe('when options.qs = true', function () {
     it('should support nested query strings', function (done) {
-      var app = koala({
+      var app = new Koala({
         qs: true
       })
       app.use(function* (next) {


### PR DESCRIPTION
I had some old code converting koala into a class (so it would have the same usage as Koa 2 which is a class). Since it would have conflicted with https://github.com/koajs/koala/pull/47 I decided to rebase onto it so I could show you this, and you can optionally merge this into your pull request branch if you like the syntax.

Note that we would at least need to make documentation changes in the readme. Tests should have the same failures, as far as I'm aware this doesn't introduce any regressions as long as you replace `koala()` with `new Koala()`.